### PR TITLE
Make search operate on labels instead of def names.

### DIFF
--- a/Source/AdaptiveStorage/ContentsITab.cs
+++ b/Source/AdaptiveStorage/ContentsITab.cs
@@ -179,7 +179,7 @@ public class ContentsITab : ITab_ContentsBase
 
 			hasAnyStoredThing = true;
 
-			if (!filter.Matches((thing.GetInnerIfMinified() ?? thing).def))
+			if (!filter.Matches((thing.GetInnerIfMinified() ?? thing).LabelCap))
 				continue;
 
 			if (scrollView.CanCull(thingRowHeight, curY))

--- a/Source/AdaptiveStorage/ContentsITab.cs
+++ b/Source/AdaptiveStorage/ContentsITab.cs
@@ -179,7 +179,7 @@ public class ContentsITab : ITab_ContentsBase
 
 			hasAnyStoredThing = true;
 
-			if (!filter.Matches((thing.GetInnerIfMinified() ?? thing).LabelCap))
+			if (!filter.Matches((thing.GetInnerIfMinified() ?? thing).Label))
 				continue;
 
 			if (scrollView.CanCull(thingRowHeight, curY))


### PR DESCRIPTION
I've noticed that the search in the Contents and Group tab appears broken; things that are clearly on the name do not show up, and sometimes extraneous things appear. It appears the reason this happens is because the filter matches on the def's label, and not the thing's label.

The call to `filter.Matches(ThingDef)` has the following signature in `QuickSearchFilte`r:

```cs
public bool Matches(ThingDef td) => !Find.HiddenItemsManager.Hidden(td) && this.Matches(td.label);
```

When passing in the def, as is what happens on line 182 of `ContentsITab`, the def's label is used, which does not reflect what a user would see on screen or what they would search by. By modifying it to use `LabelCap`, this should address the problem. It now searches correctly across stuff ("Plasteel <thing>"), quality ("Good"), and more.

### Before
You looking for "pl" and getting plasteel? Think again! It's actually searching on "pl" as in the def for "simple helmet".
<img width="450" height="406" alt="image" src="https://github.com/user-attachments/assets/abd3b42d-a8a6-4ae9-ae37-37afcd1fc869" />

Looking for good quality items? Nope.
<img width="448" height="423" alt="image" src="https://github.com/user-attachments/assets/593f4222-12a9-4a93-8e2d-46314da58e23" />

Everything made of them muffalos? Ain't gonna happen.
<img width="446" height="422" alt="image" src="https://github.com/user-attachments/assets/27d59a06-8465-4def-a090-1e7856d712e9" />


### After
Looks for "pla". Plasteel works, but also plainleather. Now it supports searching by stuff (so long as it's in the name).
<img width="455" height="440" alt="2025 12 21 13 53 24" src="https://github.com/user-attachments/assets/2fa3eef5-ac3c-4059-8579-19a25223aef4" />

Searching by quality works as well.
<img width="445" height="425" alt="image" src="https://github.com/user-attachments/assets/cf9f0f5a-4d31-4f98-b2cf-f8061aea42aa" />

Muffalo goodies my beloved!
<img width="440" height="416" alt="image" src="https://github.com/user-attachments/assets/7b704140-bdcd-4748-a2e5-0343e04a92d4" />
