### PR TITLE
Option to open Group storage tabs if buildings are grouped

### DIFF
--- a/Languages/English/Keyed/Keys.xml
+++ b/Languages/English/Keyed/Keys.xml
@@ -13,6 +13,8 @@
 	<ASF_StorageCapacityDescriptionStacksPerCell>The maximum number of stacks fitting into this storage building for all cells combined.\n\n{sizeX} * {sizeZ} cells with a maximum capacity of {maxItemsInCell} stacks per cell.</ASF_StorageCapacityDescriptionStacksPerCell>
 	<ASF_AutomaticallyOpenContentsTab>Automatically open contents tab</ASF_AutomaticallyOpenContentsTab>
 	<ASF_AutomaticallyOpenContentsTabDescription>Selecting a storage building automatically opens its Contents tab with this enabled, or storage settings when empty.</ASF_AutomaticallyOpenContentsTabDescription>
+	<ASF_PreferGroupTabWhenGrouped>Prefer group content tab if available</ASF_PreferGroupTabWhenGrouped>
+	<ASF_PreferGroupTabWhenGroupedDescription>When a storage building is part of a storage group, automatically open the group contents tab. It will take precedence over the content tab of a singular building.</ASF_PreferGroupTabWhenGroupedDescription>
 	<ASF_HideLabelsZoomSetting>Hide labels when zoomed out</ASF_HideLabelsZoomSetting>
 	<ASF_HideLabelsZoomDescription>Affects labels shown on the map, like [ count ] or Item xY. Only show them at a close zoom level when enabled.</ASF_HideLabelsZoomDescription>
 	<ASF_HideLabelsMouseOverSetting>Hide labels until mouseover</ASF_HideLabelsMouseOverSetting>

--- a/Source/AdaptiveStorage/AdaptiveStorageFrameworkSettings.cs
+++ b/Source/AdaptiveStorage/AdaptiveStorageFrameworkSettings.cs
@@ -185,7 +185,7 @@ public class AdaptiveStorageFrameworkSettings : ModSettings
 	{
 		Scribe_Values.Look(ref _contentsTabTypeName, nameof(ContentsTabType));
 		Scribe_Values.Look(ref _automaticallyOpenContentsTab, nameof(AutomaticallyOpenContentsTab), true);
-		Scribe_Values.Look(ref _preferGroupTabWhenGrouped, nameof(PreferGroupTabWhenGrouped), true);
+		Scribe_Values.Look(ref _preferGroupTabWhenGrouped, nameof(PreferGroupTabWhenGrouped));
 		Scribe_Values.Look(ref _contentLabelStyleName, nameof(ContentLabelStyle));
 		Scribe_Values.Look(ref _hideLabelsUntilMouseOver, nameof(HideLabelsUntilMouseOver));
 		Scribe_Values.Look(ref _hideLabelsWhenZoomedOut, nameof(HideLabelsWhenZoomedOut), true);

--- a/Source/AdaptiveStorage/AdaptiveStorageFrameworkSettings.cs
+++ b/Source/AdaptiveStorage/AdaptiveStorageFrameworkSettings.cs
@@ -33,6 +33,8 @@ public class AdaptiveStorageFrameworkSettings : ModSettings
 
 	public static bool AutomaticallyOpenContentsTab => _automaticallyOpenContentsTab;
 
+	public static bool PreferGroupTabWhenGrouped => _preferGroupTabWhenGrouped;
+
 	public static bool HideLabelsUntilMouseOver => _hideLabelsUntilMouseOver;
 
 	public static bool HideLabelsWhenZoomedOut => _hideLabelsWhenZoomedOut;
@@ -49,6 +51,7 @@ public class AdaptiveStorageFrameworkSettings : ModSettings
 
 	private static bool
 		_automaticallyOpenContentsTab = true,
+		_preferGroupTabWhenGrouped,
 		_hideLabelsWhenZoomedOut = true,
 		_hideLabelsUntilMouseOver;
 
@@ -113,7 +116,13 @@ public class AdaptiveStorageFrameworkSettings : ModSettings
 		listing.Gap();
 		listing.CheckboxLabeled(Strings.Translated.ASF_AutomaticallyOpenContentsTab,
 			ref _automaticallyOpenContentsTab, Strings.Translated.ASF_AutomaticallyOpenContentsTabDescription);
-		
+
+		if (_automaticallyOpenContentsTab)
+		{
+			listing.CheckboxLabeled(Strings.Translated.ASF_PreferGroupTabWhenGrouped,
+				ref _preferGroupTabWhenGrouped, Strings.Translated.ASF_PreferGroupTabWhenGroupedDescription);
+		}
+
 		listing.Gap();
 		listing.Label(Strings.Translated.ASF_DefaultLabelStyleSetting,
 			tooltip: Strings.Translated.ASF_DefaultLabelStyleDescription);
@@ -176,6 +185,7 @@ public class AdaptiveStorageFrameworkSettings : ModSettings
 	{
 		Scribe_Values.Look(ref _contentsTabTypeName, nameof(ContentsTabType));
 		Scribe_Values.Look(ref _automaticallyOpenContentsTab, nameof(AutomaticallyOpenContentsTab), true);
+		Scribe_Values.Look(ref _preferGroupTabWhenGrouped, nameof(PreferGroupTabWhenGrouped), true);
 		Scribe_Values.Look(ref _contentLabelStyleName, nameof(ContentLabelStyle));
 		Scribe_Values.Look(ref _hideLabelsUntilMouseOver, nameof(HideLabelsUntilMouseOver));
 		Scribe_Values.Look(ref _hideLabelsWhenZoomedOut, nameof(HideLabelsWhenZoomedOut), true);

--- a/Source/AdaptiveStorage/InspectTabUtility.cs
+++ b/Source/AdaptiveStorage/InspectTabUtility.cs
@@ -43,29 +43,34 @@ public static class InspectTabUtility
 	public static void TryOpen(ISelectable selectable) // for automatic tab opening, similar to LWM's
 		// https://github.com/lilwhitemouse/RimWorld-LWM.DeepStorage/blob/master/DeepStorage/Deep_Storage_ITab.cs#L237-L306
 	{
-		if (!AdaptiveStorageFrameworkSettings.AutomaticallyOpenContentsTab
-			|| Find.Selector.NumSelected > 1
-			|| selectable.GetInspectTabs() is not { } inspectTabs)
-		{
+		if (!AdaptiveStorageFrameworkSettings.AutomaticallyOpenContentsTab || selectable.GetInspectTabs() is not { } inspectTabs)
 			return;
-		}
 
 		using var tabs = inspectTabs.ToPooledList();
 
-		if (tabs.Count == 0
-			|| tabs.Exists(static tab
-				=> InspectPaneUtility.IsOpen(tab, (MainTabWindow_Inspect)MainButtonDefOf.Inspect.TabWindow)))
+		if (tabs.Count == 0)
+			return;
+
+		var tabAlreadyOpened = tabs.Exists(static tab => InspectPaneUtility.IsOpen(tab, (MainTabWindow_Inspect)MainButtonDefOf.Inspect.TabWindow));
+		if (tabAlreadyOpened)
+			return;
+
+		var groupTab = AdaptiveStorageFrameworkSettings.PreferGroupTabWhenGrouped
+			? tabs.Find(static tab => tab is GroupContentsITab)
+			: null;
+
+		if (groupTab != null && groupTab.IsVisible)
 		{
+			InspectPaneUtility.OpenTab(groupTab.GetType());
 			return;
 		}
 
 		var selectedContentsTab = AdaptiveStorageFrameworkSettings.ContentsTab;
+		var selectedContentsTabExists = selectedContentsTab is not null && tabs.Contains(selectedContentsTab) && selectedContentsTab.IsVisible;
 
-		var tab = selectedContentsTab is null
-			|| !tabs.Contains(selectedContentsTab)
-			|| !selectedContentsTab.IsVisible
-				? tabs.Find(static tab => tab is ITab_Storage)
-				: selectedContentsTab;
+		var tab = selectedContentsTabExists
+					? selectedContentsTab
+					: tabs.Find(static tab => tab is ITab_Storage);
 
 		if (tab is null)
 			return;

--- a/Source/AdaptiveStorage/InspectTabUtility.cs
+++ b/Source/AdaptiveStorage/InspectTabUtility.cs
@@ -51,7 +51,12 @@ public static class InspectTabUtility
 		if (tabs.Count == 0)
 			return;
 
-		var tabAlreadyOpened = tabs.Exists(static tab => InspectPaneUtility.IsOpen(tab, (MainTabWindow_Inspect)MainButtonDefOf.Inspect.TabWindow));
+		// IsVisible means we only consider tabs that are actually visible; i.e. present in the tab list of the newly clicked selectable.
+		// This is relevant for example when you have a grouped storage building selected and click onto an individual, ungrouped one.
+		// In that scenario, without the IsVisible check, we'd return here and not display any tabs.
+		var tabAlreadyOpened = tabs.Exists(static tab => tab.IsVisible
+			&& InspectPaneUtility.IsOpen(tab, (MainTabWindow_Inspect)MainButtonDefOf.Inspect.TabWindow));
+
 		if (tabAlreadyOpened)
 			return;
 

--- a/Source/AdaptiveStorage/Strings.cs
+++ b/Source/AdaptiveStorage/Strings.cs
@@ -89,6 +89,8 @@ public static class Strings
 			ASF_StorageCapacityDescriptionStacksPerCell,
 			ASF_AutomaticallyOpenContentsTab,
 			ASF_AutomaticallyOpenContentsTabDescription,
+			ASF_PreferGroupTabWhenGrouped,
+			ASF_PreferGroupTabWhenGroupedDescription,
 			ASF_HideLabelsZoomSetting,
 			ASF_HideLabelsZoomDescription,
 			ASF_HideLabelsMouseOverSetting,


### PR DESCRIPTION
<img width="1210" height="404" alt="image" src="https://github.com/user-attachments/assets/a35331d0-36b4-4490-bdcc-72a18df4eb8d" />

I like grouping my storage buildings and noticed this wasn't supported: with the auto open it would always open the Storage tab even when grouped. Attempted to add that.

Changes:
1. with the new option enabled, if the storage building has a group tab, it'll take precedence over the Contents tab.
2. when selecting multiple storage buildings, the Contents tab will remain open as in 1.6 the contents get aggregated when shift + clicking ungrouped storages.


When going from one storage building to the next, if a relevant tab is open, it will remain open. So:
- if you have the **Storage settings tab open** and click on another storage building, it will **remain open**.
- if you have the **Contents tab open** and click on another storage building, it will **remain open**.
- if you have the **Group tab open** and click on an ungrouped storage building, it will **open the Contents tab instead**.

This last one might be a bit iffy because when you go back to the grouped building it'll open Contents. That's consistent, though, although not 100% desired maybe. Opening the Group tab could be better in that scenario but would break the consistency of the behavior.

The option starts as false, didn't want to assume intended the behavior, but I think it makes sense to take priority by default.

I tested this with just VSF and storage furniture mods, and also have been using it for the last few hours on my save with ~450 mods.

https://streamable.com/yc6jys

