### PR TITLE
StorageRenderer: never resolve item graphic during SetPrintDataDirty

### DIFF
--- a/Source/AdaptiveStorage/StorageRenderer.cs
+++ b/Source/AdaptiveStorage/StorageRenderer.cs
@@ -645,10 +645,8 @@ public class StorageRenderer : ITransformable.ITransformable
 		else
 		{
 			if (TryGetPrintDataOf(thing) is not { } printData)
-			{
 				printData = AddPrintData(thing,
-					UnityData.IsInMainThread ? itemGraphic.Worker.GetGraphicFor(thing, this) : null);
-			}
+					UnityData.IsInMainThread && !Multiplayer.API.MP.enabled ? itemGraphic.Worker.GetGraphicFor(thing, this) : null);
 
 			printData.Dirty = true;
 			AnyPrintDatasDirty = true;


### PR DESCRIPTION
## Summary
- Add `&& !Multiplayer.API.MP.enabled` to `SetPrintDataDirty`'s graphic-resolution conditional, so MP always defers graphic resolution to the render pass while SP keeps the original main-thread fast path.
- Fixes a RimWorld Multiplayer desync caused by asymmetric `Verse.Rand` consumption between host and client during load.

## The bug
[`SetPrintDataDirty`](https://github.com/bbradson/Adaptive-Storage-Framework/blob/main/Source/AdaptiveStorage/StorageRenderer.cs#L648) currently does:

```csharp
printData = AddPrintData(thing,
    UnityData.IsInMainThread ? itemGraphic.Worker.GetGraphicFor(thing, this) : null);
```

The `IsInMainThread` check produces divergent behaviour between MP host and client even though both load the same save bytes with the same deterministic seed:

| Side | Load path | Thread | `IsInMainThread` | `GetGraphicFor` | Verse.Rand consumed |
|---|---|---|---|---|---|
| Host | `SaveLoad.LoadInMainThread` → direct `LoadGameFromSaveFileNow` | Main | `true` | Called | **Yes** |
| Client | `Root_Play.Start` → `LongEventHandler.QueueLongEvent(doAsynchronously: true)` → `LoadGameFromSaveFileNow` | Worker | `false` | Skipped | **No** |

MP wraps `Map.FinalizeLoading` in a `Rand.PushState` seeded by `HashCombineInt(map.uniqueID, World.ConstantRandSeed)`. Inside that seeded scope, host reaches `Graphic_Random.get_MatSingle` via `SetPrintDataDirty` → one `Rand.Range` per stored-item graphic. Client skips that call entirely. The resulting N-iteration offset in the Mersenne stream causes every subsequent seeded consumer during load (notably `RoomTempTracker.RegenerateEqualizeCells.Shuffle`) to produce different outputs on each side. Within ~120 ticks the downstream temperature drift propagates into a `FreezeManager.DoIceMelting` `Rand.Chance` boundary and the main RNG stream desyncs.

## The fix
Add `!Multiplayer.API.MP.enabled` to the existing condition. Under MP, both sides take the `null` branch and graphic resolution defers to [`UpdateDirtyPrintDatas`](https://github.com/bbradson/Adaptive-Storage-Framework/blob/main/Source/AdaptiveStorage/StorageRenderer.cs#L596-L619) on the next render pass (always main thread). In SP, behaviour is unchanged.

## Performance
- **SP:** unchanged — still resolves at spawn on main thread.
- **MP:** load/spawn time slightly faster (skips per-item `GetGraphicFor`); first render after spawn slightly slower (one `RemovePrintData` + `AddPrintData` per printData when `UpdateDirtyPrintDatas` sees `printable.Graphic == null`). Steady-state rendering identical. Net cost in MP is negligible — first-render hit is amortised across the frames the camera takes to bring containers on-screen.

## Evidence
Probe instrumentation captured on a reproducing MP save:

- **Host iter=0,1** of `SeedMapFinalizeLoading`'s scope: `Verse.Rand.Range ← Graphic_Random.get_MatSingle ← AdaptiveStorage.StorageRenderer.SetPrintDataDirty ← ThingCollection.Add ← ThingClass.InitializeStoredThings ← Map.FinalizeLoading ← SaveLoad.LoadInMainThread`
- **Client iter=0**: `Verse.Rand.Range ← Shuffle ← GenList.Shuffle ← RegenerateEqualizeCells` (no AS chain present; worker thread took the `null` branch).

Resulting `equalizeCells` for room 45 at tick 9954127: host ended at `(135,142),(132,153),(119,155),…` with `roomT=9.727`; client at `(117,148),(117,153),(139,149),…` with `roomT=9.745`. Reproducible across runs.

Credit: mechanism identified by @bbradson in direct discussion. Conditional-rather-than-unconditional approach (preserving SP fast path) per @bbradson's review feedback.

## Test plan
- [x] Builds cleanly (`dotnet build Source/AdaptiveStorage/AdaptiveStorage.1.6.csproj -c Release`)
- [x] Deployed to test install
- [x] MP repro: host previously-desyncing save, client joins. Expect no desync past the prior divergence point (mapTick 9954128, r=45 shuffle).
- [x] SP visual check: stored items still render with graphic resolved at spawn (unchanged from current behaviour).